### PR TITLE
Fix wrong font size for cx-title-5

### DIFF
--- a/packages/lib/global-css/typography.css
+++ b/packages/lib/global-css/typography.css
@@ -45,7 +45,7 @@ button {
 
 .cx-title-5 {
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: 1.125rem;
   line-height: 1.125;
 }
 

--- a/stories/Typography.mdx
+++ b/stories/Typography.mdx
@@ -12,11 +12,11 @@ import { Meta, Subtitle, Title } from '@storybook/blocks';
 <table>
   <thead>
     <tr>
+      <th>Class</th>
       <th>Example</th>
       <th>Size</th>
       <th>Weight</th>
       <th>Line-height</th>
-      <th>Class</th>
     </tr>
   </thead>
 
@@ -64,11 +64,11 @@ import { Meta, Subtitle, Title } from '@storybook/blocks';
 <table>
   <thead>
     <tr>
+      <th>Class</th>
       <th>Example</th>
       <th>Size</th>
       <th>Weight</th>
       <th>Line-height</th>
-      <th>Class</th>
     </tr>
   </thead>
 
@@ -173,11 +173,11 @@ import { Meta, Subtitle, Title } from '@storybook/blocks';
 <table>
   <thead>
     <tr>
+      <th>Class</th>
       <th>Example</th>
       <th>Size</th>
       <th>Weight</th>
       <th>Line-height</th>
-      <th>Class</th>
     </tr>
   </thead>
 


### PR DESCRIPTION
## ✨ Endringer i denne PRen

- I denne PRen har jeg endret cx-title-5 font size til 1.125rem (18px) - var .875rem (14px)
- Jeg har også endret rekkefølgen på headere i tabellene for typography

## 📖 Huskeliste

- [ ] Jeg har sjekket at løsningen tilfredstiller WCAG-krav for tilgjengelighet
