### PR TITLE
Vise landingpage.mdx som default forside for designsystemet

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,6 +14,11 @@ const preview: Preview = {
     docs: {
       toc: true,
     },
+    options: {
+      storySort: {
+        order: ['Designsystemet vårt', 'Basics', 'Components'],
+      },
+    },
   },
   decorators: [
     withThemeByClassName({


### PR DESCRIPTION
## ✨ Endringer i denne PRen

- I denne PRen blir nå landingPage.mdx vist korrekt som forsiden til designsystemet

