### PR TITLE
Endre til samme fargekode for less-important tekst som i figma

### DIFF
--- a/packages/lib/global-css/purpose-color-tokens.css
+++ b/packages/lib/global-css/purpose-color-tokens.css
@@ -55,7 +55,7 @@
     --cx-color-text-accent-2: var(--cx-color-blue);
     --cx-color-text-accent-3: var(--cx-color-purple);
     --cx-color-text-inverted: var(--cx-color-grey-100);
-    --cx-color-text-less-important: var(--cx-color-grey-500);
+    --cx-color-text-less-important: var(--cx-color-grey-300);
     --cx-color-text-disabled: var(--cx-color-grey-300);
     --cx-color-text-static-dark: var(--cx-color-grey-700);
     --cx-color-text-static-light: var(--cx-color-grey-100);


### PR DESCRIPTION
## ✨ Endringer i denne PRen

- I denne PRen har jeg endret til samme fargekode for less-important tekst som i figma
- Vi ble gjort oppmerksom på at det nå ble brukt #477494 istedet for #93B5CD (som brukes i figmaskissene for chubben web)
